### PR TITLE
bugfix: fix sqlmesh_execution_status regression

### DIFF
--- a/src/dg_sqlmesh/simple_run_tracker.py
+++ b/src/dg_sqlmesh/simple_run_tracker.py
@@ -7,6 +7,7 @@ import typing as t
 from sqlmesh.core.console import NoopConsole
 from sqlmesh.core.snapshot.definition import Snapshot, SnapshotId
 from contextlib import contextmanager
+from sqlmesh.core.snapshot.definition import Interval
 
 
 class SimpleRunTracker(NoopConsole):
@@ -29,13 +30,14 @@ class SimpleRunTracker(NoopConsole):
     def update_snapshot_evaluation_progress(
         self,
         snapshot: Snapshot,
-        interval: t.Any,
-        _batch_idx: int,
-        _duration_ms: t.Optional[int],
-        _num_audits_passed: int,
-        _num_audits_failed: int,
-        _audit_only: bool = False,
-        _auto_restatement_triggers: t.Optional[t.List[SnapshotId]] = None,
+        interval: Interval,
+        batch_idx: int,
+        duration_ms: t.Optional[int],
+        num_audits_passed: int,
+        num_audits_failed: int,
+        audit_only: bool = False,
+        execution_stats: t.Optional[t.Any] = None,
+        auto_restatement_triggers: t.Optional[t.List[SnapshotId]] = None,
     ) -> None:
         """Track executed model."""
         self.executed_models.add(snapshot.name)


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The  AssetCheck was incorrectly reporting all models as skipped, even when they were actually executed.

### Root Cause
The method signature for  changed in newer SQLMesh versions, causing the tracker to not capture executed models.

### Solution
- Updated method signature to match newer SQLMesh version
- Changed parameter names from  to , etc.
- Added missing  import
- Added  parameter

### Testing
- All unit tests pass
- Manual testing confirms sqlmesh_execution_status now works correctly

### Impact
This fixes the regression where all models were being marked as skipped instead of executed.